### PR TITLE
feat(extension): add per-order custom notes

### DIFF
--- a/apps/extension/src/__tests__/orderFilters.test.ts
+++ b/apps/extension/src/__tests__/orderFilters.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  searchOrders,
   sortOrders,
   filterOrdersByStatus,
   filterAndSortOrders,
@@ -152,5 +153,19 @@ describe('filterAndSortOrders', () => {
   it('returns all when no filters applied', () => {
     const result = filterAndSortOrders(orders, '', 'all', 'created-desc');
     expect(result).toHaveLength(3);
+  });
+});
+
+describe('searchOrders', () => {
+  it('matches note content', () => {
+    const orders = [
+      makeOrder({ id: '1', note: 'Customer asked for fragile packaging' }),
+      makeOrder({ id: '2', note: 'Ship with signature required' }),
+    ];
+
+    const result = searchOrders(orders, 'fragile');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
   });
 });

--- a/apps/extension/src/components/OrderCard.tsx
+++ b/apps/extension/src/components/OrderCard.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
   ExternalLink,
 } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { OrderStatus, ORDER_STATUS_LABELS, type Order } from '@/types';
 import { cn } from '@/lib';
 import { Card, CardTitle } from './ui/card';
@@ -74,12 +74,15 @@ const statusConfig: Record<
 const STATUS_SEQUENCE = Object.values(OrderStatus);
 const CARD_CONTENT_WIDTH = 'mx-auto w-full max-w-none';
 
+const NOTE_DEBOUNCE_MS = 400;
+
 interface OrderCardProps {
   order: Order;
   isSelected: boolean;
   hasImageError: boolean;
   onToggleSelect: (orderId: string) => void;
   onStatusChange: (orderId: string, status: OrderStatus) => void;
+  onNoteSave: (orderId: string, note: string) => void;
   onDelete: (orderId: string) => void;
   onImageError: (orderId: string) => void;
 }
@@ -90,9 +93,39 @@ function OrderCardImpl({
   hasImageError,
   onToggleSelect,
   onStatusChange,
+  onNoteSave,
   onDelete,
   onImageError,
 }: OrderCardProps) {
+  const savedNote = order.note ?? '';
+  const [draftNote, setDraftNote] = useState(savedNote);
+  const lastSavedRef = useRef(savedNote);
+
+  // Reconcile local draft when the order's note changes from outside (e.g. sync).
+  // Only overwrite if we've saved everything we typed, to avoid clobbering an in-flight edit.
+  useEffect(() => {
+    if (draftNote === lastSavedRef.current) {
+      lastSavedRef.current = savedNote;
+      setDraftNote(savedNote);
+    }
+  }, [savedNote, draftNote]);
+
+  // Debounced save: fires 400 ms after the last keystroke.
+  useEffect(() => {
+    if (draftNote === lastSavedRef.current) return;
+    const timer = setTimeout(() => {
+      lastSavedRef.current = draftNote;
+      onNoteSave(order.id, draftNote);
+    }, NOTE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [draftNote, order.id, onNoteSave]);
+
+  const flushNote = () => {
+    if (draftNote === lastSavedRef.current) return;
+    lastSavedRef.current = draftNote;
+    onNoteSave(order.id, draftNote);
+  };
+
   return (
     <Card
       elevation={isSelected ? 'high' : 'medium'}
@@ -221,29 +254,41 @@ function OrderCardImpl({
             <span className="text-[11px] text-muted-foreground/80">
               Placed {order.orderDate}
             </span>
-            <div className="ml-auto flex gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  const sanitized = order.orderNumber.replace(/\s+/g, '');
-                  const url = `https://www.amazon.com/gp/css/order-details?orderID=${encodeURIComponent(sanitized)}`;
-                  window.open(url, '_blank', 'noopener');
-                }}
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary transition hover:bg-primary/15"
-                aria-label="Track order"
-              >
-                <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              </button>
-              <button
-                type="button"
-                onClick={() => onDelete(order.id)}
-                className="flex h-8 w-8 items-center justify-center rounded-full border border-destructive/30 text-destructive transition hover:bg-destructive/10"
-                aria-label="Remove order"
-              >
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-              </button>
-            </div>
           </div>
+        </div>
+      </div>
+      <div className={cn(CARD_CONTENT_WIDTH, 'px-6 pb-4')}>
+        <div className="flex min-w-0 items-center gap-2">
+          <input
+            id={`order-note-${order.id}`}
+            type="text"
+            value={draftNote}
+            onChange={(event) => setDraftNote(event.target.value)}
+            onBlur={flushNote}
+            placeholder="Add a note..."
+            autoComplete="off"
+            className="min-w-0 flex-1 rounded-full border border-border/70 bg-muted/35 px-4 py-2.5 text-sm text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.08)] outline-none transition placeholder:text-muted-foreground/70 focus:border-primary/40 focus:ring-4 focus:ring-primary/10"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const sanitized = order.orderNumber.replace(/\s+/g, '');
+              const url = `https://www.amazon.com/gp/css/order-details?orderID=${encodeURIComponent(sanitized)}`;
+              window.open(url, '_blank', 'noopener');
+            }}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary transition hover:bg-primary/15"
+            aria-label="Track order"
+          >
+            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(order.id)}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-destructive/30 text-destructive transition hover:bg-destructive/10"
+            aria-label="Remove order"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
         </div>
       </div>
     </Card>

--- a/apps/extension/src/components/OrderCard.tsx
+++ b/apps/extension/src/components/OrderCard.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
   ExternalLink,
 } from 'lucide-react';
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useState, type KeyboardEvent } from 'react';
 import { OrderStatus, ORDER_STATUS_LABELS, type Order } from '@/types';
 import { cn } from '@/lib';
 import { Card, CardTitle } from './ui/card';
@@ -74,8 +74,6 @@ const statusConfig: Record<
 const STATUS_SEQUENCE = Object.values(OrderStatus);
 const CARD_CONTENT_WIDTH = 'mx-auto w-full max-w-none';
 
-const NOTE_DEBOUNCE_MS = 400;
-
 interface OrderCardProps {
   order: Order;
   isSelected: boolean;
@@ -99,31 +97,28 @@ function OrderCardImpl({
 }: OrderCardProps) {
   const savedNote = order.note ?? '';
   const [draftNote, setDraftNote] = useState(savedNote);
-  const lastSavedRef = useRef(savedNote);
+  const isDirty = draftNote !== savedNote;
 
   // Reconcile local draft when the order's note changes from outside (e.g. sync).
-  // Only overwrite if we've saved everything we typed, to avoid clobbering an in-flight edit.
+  // Skip while the user has an uncommitted draft so we don't clobber their typing.
   useEffect(() => {
-    if (draftNote === lastSavedRef.current) {
-      lastSavedRef.current = savedNote;
-      setDraftNote(savedNote);
-    }
-  }, [savedNote, draftNote]);
+    if (!isDirty) setDraftNote(savedNote);
+  }, [savedNote, isDirty]);
 
-  // Debounced save: fires 400 ms after the last keystroke.
-  useEffect(() => {
-    if (draftNote === lastSavedRef.current) return;
-    const timer = setTimeout(() => {
-      lastSavedRef.current = draftNote;
-      onNoteSave(order.id, draftNote);
-    }, NOTE_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [draftNote, order.id, onNoteSave]);
-
-  const flushNote = () => {
-    if (draftNote === lastSavedRef.current) return;
-    lastSavedRef.current = draftNote;
+  const commitNote = () => {
+    if (!isDirty) return;
     onNoteSave(order.id, draftNote);
+  };
+
+  const handleNoteKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitNote();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setDraftNote(savedNote);
+      event.currentTarget.blur();
+    }
   };
 
   return (
@@ -264,11 +259,26 @@ function OrderCardImpl({
             type="text"
             value={draftNote}
             onChange={(event) => setDraftNote(event.target.value)}
-            onBlur={flushNote}
+            onKeyDown={handleNoteKeyDown}
             placeholder="Add a note..."
             autoComplete="off"
-            className="min-w-0 flex-1 rounded-full border border-border/70 bg-muted/35 px-4 py-2.5 text-sm text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.08)] outline-none transition placeholder:text-muted-foreground/70 focus:border-primary/40 focus:ring-4 focus:ring-primary/10"
+            title="Press Enter to save · Esc to discard"
+            aria-describedby={isDirty ? `order-note-${order.id}-hint` : undefined}
+            className={cn(
+              'min-w-0 flex-1 rounded-full border bg-muted/35 px-4 py-2.5 text-sm text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.08)] outline-none transition placeholder:text-muted-foreground/70 focus:ring-4 focus:ring-primary/10',
+              isDirty
+                ? 'border-primary/60 focus:border-primary'
+                : 'border-border/70 focus:border-primary/40',
+            )}
           />
+          {isDirty ? (
+            <span
+              id={`order-note-${order.id}-hint`}
+              className="hidden shrink-0 text-[11px] text-muted-foreground sm:inline"
+            >
+              Enter to save · Esc to cancel
+            </span>
+          ) : null}
           <button
             type="button"
             onClick={() => {

--- a/apps/extension/src/components/OrderTable.tsx
+++ b/apps/extension/src/components/OrderTable.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useDeleteOrders, useOrders, useUpdateOrderStatus } from '@/hooks/useOrders';
+import {
+  useDeleteOrders,
+  useOrders,
+  useUpdateOrderNote,
+  useUpdateOrderStatus,
+} from '@/hooks/useOrders';
 import type { OrderStatus } from '@/types';
 import type { OrderSortOption, StatusFilter } from '@/utils/orderFilters';
 import { filterAndSortOrders } from '@/utils/orderFilters';
@@ -16,8 +21,10 @@ export function OrderTable() {
   // TanStack Query hooks
   const { data: orders = [], isLoading } = useOrders();
   const updateStatusMutation = useUpdateOrderStatus();
+  const updateNoteMutation = useUpdateOrderNote();
   const deleteOrdersMutation = useDeleteOrders();
   const { mutate: mutateStatus } = updateStatusMutation;
+  const { mutate: mutateNote } = updateNoteMutation;
   const { mutateAsync: mutateDelete, isPending: isDeleting } = deleteOrdersMutation;
 
   // UI state (local - no need for global store)
@@ -132,6 +139,13 @@ export function OrderTable() {
     [mutateStatus],
   );
 
+  const handleNoteSave = useCallback(
+    (orderId: string, note: string) => {
+      mutateNote({ id: orderId, note });
+    },
+    [mutateNote],
+  );
+
   const handleClearSearch = useCallback(() => setSearchQuery(''), []);
 
   const scrollParentRef = useRef<HTMLDivElement>(null);
@@ -211,6 +225,7 @@ export function OrderTable() {
                     hasImageError={imageFailures.has(order.id)}
                     onToggleSelect={toggleSelect}
                     onStatusChange={handleStatusChange}
+                    onNoteSave={handleNoteSave}
                     onDelete={handleDeleteSingle}
                     onImageError={handleImageError}
                   />

--- a/apps/extension/src/hooks/useOrders.ts
+++ b/apps/extension/src/hooks/useOrders.ts
@@ -69,6 +69,45 @@ export function useUpdateOrderStatus() {
 }
 
 /**
+ * Update order note
+ */
+export function useUpdateOrderNote() {
+  const queryClient = useQueryClient();
+  const { isAuthenticated, user } = useAuth();
+
+  return useMutation({
+    mutationFn: async ({ id, note }: { id: string; note: string }) => {
+      const updatedAt = new Date().toISOString();
+      const nextNote = note.trim() ? note : undefined;
+
+      await localRepository.update(id, { note: nextNote, updatedAt });
+
+      if (isAuthenticated && user) {
+        const order = await localRepository.getById(id);
+        if (order) {
+          syncQueue.add({ type: 'upsert', order: { ...order, userId: user.sub } });
+        }
+      }
+    },
+    onMutate: async ({ id, note }) => {
+      await queryClient.cancelQueries({ queryKey: ORDERS_KEY });
+      const previousOrders = queryClient.getQueryData<Order[]>(ORDERS_KEY);
+      const nextNote = note.trim() ? note : undefined;
+      queryClient.setQueryData<Order[]>(ORDERS_KEY, (old) =>
+        old?.map((order) => (order.id === id ? { ...order, note: nextNote } : order))
+      );
+      return { previousOrders };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previousOrders) queryClient.setQueryData(ORDERS_KEY, context.previousOrders);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ORDERS_KEY });
+    },
+  });
+}
+
+/**
  * Delete orders (unified soft delete)
  */
 export function useDeleteOrders() {


### PR DESCRIPTION
## Summary
- Adds a note input to each OrderCard; notes commit **only on Enter**, Esc discards the draft. Auto-save was intentionally removed after review feedback.
- While a draft differs from the saved value the input border turns primary-colored and a "Enter to save · Esc to cancel" hint appears.
- Notes are already searchable via `searchOrders` and fit the existing schema, so no schema changes were needed.

## Context
Supersedes #15 by @SmallNeon — same feature, rebased on `main`. Original PR used per-keystroke writes; this PR uses explicit commit only. Unrelated `actions/checkout@v4 → v5` bumps from #15 are not included. Credit via `Co-authored-by` trailer on the first commit.

## Test plan
- [x] `bun run typecheck` + `bun run lint` + `bun run test` green (pre-commit hook verified).
- [x] Manual end-to-end in a polyfilled build: typing leaves `chrome.storage` writes at **0**; Enter produces exactly **1** write with the typed note; Esc reverts the input to the last saved value with no additional writes; dirty-state border toggles correctly.
- [ ] Smoke test in the real extension (load unpacked, type note, press Enter, confirm persistence across reload).
- [ ] Signed in: Enter produces one server upsert in the network tab.
- [ ] Regressions: status buttons, delete, and Track-order link still behave as before.