### PR TITLE
fix: show Save Order on first Amazon Orders page

### DIFF
--- a/apps/extension/src/__tests__/contentMatches.test.ts
+++ b/apps/extension/src/__tests__/contentMatches.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { AMAZON_ORDER_PAGE_MATCHES } from '../constants';
+
+describe('Amazon order page content script matches', () => {
+  it('includes the first Your Orders route', () => {
+    expect(AMAZON_ORDER_PAGE_MATCHES).toContain('*://*.amazon.com/gp/css/order-history*');
+  });
+});

--- a/apps/extension/src/constants/index.ts
+++ b/apps/extension/src/constants/index.ts
@@ -1,6 +1,13 @@
 // Query keys
 export const ORDERS_KEY = ['orders'] as const;
 
+// Content script matches
+export const AMAZON_ORDER_PAGE_MATCHES = [
+  '*://*.amazon.com/gp/css/order-history*',
+  '*://*.amazon.com/gp/your-account/order-history*',
+  '*://*.amazon.com/your-orders/orders*',
+] as const;
+
 // Storage keys
 export const AUTH_STORAGE_KEY = 'auth_user';
 export const CURRENT_USER_STORAGE_KEY = 'currentUser';

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -10,12 +10,10 @@ import {
   showRefreshFeedback,
 } from '@/content/injector';
 import { initFBMarketplace } from '@/content/fbMarketplace';
+import { AMAZON_ORDER_PAGE_MATCHES } from '@/constants';
 
 export default defineContentScript({
-  matches: [
-    '*://*.amazon.com/gp/your-account/order-history*',
-    '*://*.amazon.com/your-orders/orders*',
-  ],
+  matches: [...AMAZON_ORDER_PAGE_MATCHES],
   runAt: 'document_idle',
   main() {
     initializeErrorHandlers();

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,9 +1,12 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const srcDirectory = fileURLToPath(new URL('./src', import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@': '/Users/spenc/order-wizard/apps/extension/src',
+      '@': srcDirectory,
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- register the content script on Amazon's `/gp/css/order-history` entry route
- centralize the supported Amazon Orders match patterns and add a regression test
- make the Vitest source alias portable across developer machines

## Root cause

The first Your Orders page uses `/gp/css/order-history`, but the extension only registered its content script for an older order-history path and the paginated `/your-orders/orders` route. The script therefore did not run until the user navigated to the next page.

## Verification

- manually verified the unpacked production build shows Save Order on the first Orders page
- `bun run typecheck`
- `bun run lint` (passes with pre-existing warnings)
- `bun run test` (59 tests)
- `bun run build`

`cargo clippy` was not available locally because the Rust toolchain is not installed; server code is unchanged.
